### PR TITLE
refactor: unify confirmation modes

### DIFF
--- a/src/utils/confirm.ts
+++ b/src/utils/confirm.ts
@@ -23,8 +23,7 @@ function sleep(ms: number): Promise<void> {
  * Display AI-generated content and get user confirmation.
  * Behavior depends on execution mode:
  * - auto-accept: Shows content briefly, returns "accept"
- * - confirm-each: Shows content, waits for Enter, returns "accept"
- * - interactive: Returns "interactive" to signal full action loop needed
+ * - confirm-each/interactive: Returns "interactive" to signal full action loop needed
  */
 export async function confirmWithMode(
 	options: ConfirmWithModeOptions,
@@ -42,21 +41,7 @@ export async function confirmWithMode(
 		return "accept";
 	}
 
-	if (isConfirmEachMode()) {
-		// Simple confirmation - press Enter to continue
-		const confirmed = await p.confirm({
-			message: `Accept this ${contentLabel.toLowerCase()}?`,
-			initialValue: true,
-		});
-
-		if (p.isCancel(confirmed) || !confirmed) {
-			return "cancel";
-		}
-
-		return "accept";
-	}
-
-	// Interactive mode - return control to caller for full action loop
+	// Both confirm-each and interactive modes use the full action loop
 	return "interactive";
 }
 


### PR DESCRIPTION
This pull request simplifies the confirmation logic in the `confirmWithMode` function. Now, both `confirm-each` and `interactive` modes return "interactive" to signal that the full action loop is needed, instead of handling confirmation for `confirm-each` mode within the function.

Confirmation logic simplification:

* Updated the function documentation and implementation so that both `confirm-each` and `interactive` modes return "interactive", removing the separate confirmation prompt for `confirm-each` mode. [[1]](diffhunk://#diff-a14961566d41200b67aa2afed7694ec16154e72d871824958ab9ad7d50bac730L26-R26) [[2]](diffhunk://#diff-a14961566d41200b67aa2afed7694ec16154e72d871824958ab9ad7d50bac730L45-R44)