### PR TITLE
feat: track AI edits history for contextual prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,9 @@ npm-debug.log*
 # Test coverage
 coverage/
 
+# ocmt local history
+.oc/changelog.history.json
+.oc/ai.edits.json
+
 # Local testing
 !test-repo/

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -2,6 +2,11 @@ import * as p from "@clack/prompts";
 import color from "picocolors";
 import { maybeCreateBranchForCommit } from "../lib/branch";
 import { getConfig } from "../lib/config";
+import {
+	getAiEditedOutputsContext,
+	recordAiEditedOutput,
+	recordAiEditedOutputSession,
+} from "../lib/ai-edits";
 import { cleanup, generateCommitMessage } from "../lib/opencode";
 import { maybeCreatePRAfterCommit } from "../lib/pr";
 import { confirmAction, confirmWithMode } from "../utils/confirm";
@@ -118,18 +123,25 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
 
 	// If message provided, use it directly
 	let commitMessage = options.message;
+	let originalCommitMessage: string | null = null;
+	let wasEdited = false;
 
 	if (!commitMessage) {
 		// Generate commit message using AI
 		const s = createSpinner();
 		s.start("Generating commit message");
 
+		const context = await getAiEditedOutputsContext("commit");
+
 		try {
 			commitMessage = await generateCommitMessage({
 				diff,
+				context,
 				modelOverride: options.model,
 			});
 			s.stop("Commit message generated");
+			originalCommitMessage = commitMessage;
+			wasEdited = false;
 		} catch (error) {
 			s.stop("Failed to generate commit message");
 			p.cancel(error instanceof Error ? error.message : String(error));
@@ -174,6 +186,17 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
 				}
 
 				if (action === "commit") {
+					if (
+						originalCommitMessage &&
+						wasEdited &&
+						commitMessage.trim() !== originalCommitMessage.trim()
+					) {
+						await recordAiEditedOutput({
+							kind: "commit-message",
+							generated: originalCommitMessage,
+							edited: commitMessage,
+						});
+					}
 					actionLoop = false;
 					break;
 				}
@@ -190,6 +213,14 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
 						commitMessage,
 						newIntent as string,
 					);
+					if (originalCommitMessage) {
+						wasEdited = true;
+						recordAiEditedOutputSession({
+							kind: "commit-message",
+							generated: originalCommitMessage,
+							edited: commitMessage,
+						});
+					}
 					p.log.step(
 						`Proposed commit message:\n${color.white(`  "${commitMessage}"`)}`,
 					);
@@ -210,6 +241,14 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
 					}
 
 					commitMessage = editedMessage;
+					if (originalCommitMessage) {
+						wasEdited = true;
+						recordAiEditedOutputSession({
+							kind: "commit-message",
+							generated: originalCommitMessage,
+							edited: commitMessage,
+						});
+					}
 					p.log.step(
 						`Proposed commit message:\n${color.white(`  "${commitMessage}"`)}`,
 					);
@@ -220,12 +259,17 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
 					const s = createSpinner();
 					s.start("Regenerating commit message");
 
+					const context = await getAiEditedOutputsContext("commit");
+
 					try {
 						commitMessage = await generateCommitMessage({
 							diff,
+							context,
 							modelOverride: options.model,
 						});
 						s.stop("Commit message regenerated");
+						originalCommitMessage = commitMessage;
+						wasEdited = false;
 					} catch (error) {
 						s.stop("Failed to regenerate commit message");
 						p.cancel(error instanceof Error ? error.message : String(error));

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -126,6 +126,17 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
 	let originalCommitMessage: string | null = null;
 	let wasEdited = false;
 
+	const recordCommitEdit = (edited: string) => {
+		if (originalCommitMessage) {
+			wasEdited = true;
+			recordAiEditedOutputSession({
+				kind: "commit-message",
+				generated: originalCommitMessage,
+				edited,
+			});
+		}
+	};
+
 	if (!commitMessage) {
 		// Generate commit message using AI
 		const s = createSpinner();
@@ -213,14 +224,7 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
 						commitMessage,
 						newIntent as string,
 					);
-					if (originalCommitMessage) {
-						wasEdited = true;
-						recordAiEditedOutputSession({
-							kind: "commit-message",
-							generated: originalCommitMessage,
-							edited: commitMessage,
-						});
-					}
+					recordCommitEdit(commitMessage);
 					p.log.step(
 						`Proposed commit message:\n${color.white(`  "${commitMessage}"`)}`,
 					);
@@ -241,14 +245,7 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
 					}
 
 					commitMessage = editedMessage;
-					if (originalCommitMessage) {
-						wasEdited = true;
-						recordAiEditedOutputSession({
-							kind: "commit-message",
-							generated: originalCommitMessage,
-							edited: commitMessage,
-						});
-					}
+					recordCommitEdit(commitMessage);
 					p.log.step(
 						`Proposed commit message:\n${color.white(`  "${commitMessage}"`)}`,
 					);

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -277,7 +277,6 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
 					p.log.step(
 						`Proposed commit message:\n${color.white(`  "${commitMessage}"`)}`,
 					);
-					continue;
 				}
 			}
 		}

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -177,7 +177,7 @@ export async function releaseCommand(options: ReleaseOptions): Promise<void> {
 				`Staged changes:\n${stagedPreview}${moreCount > 0 ? `\n  ${color.dim(`...and ${moreCount} more`)}` : ""}`,
 			);
 
-			let diff: string | null = await getStagedDiff();
+			const diff: string | null = await getStagedDiff();
 
 			if (diff) {
 				const branchFlow = await maybeCreateBranchForCommit({

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import * as p from "@clack/prompts";
 import color from "picocolors";
 import { maybeCreateBranchForCommit } from "../lib/branch";
+import { getAiEditedOutputsContext } from "../lib/ai-edits";
 import { addHistoryEntry } from "../lib/history";
 import {
 	cleanup,
@@ -192,7 +193,8 @@ export async function releaseCommand(options: ReleaseOptions): Promise<void> {
 				const genSpinner = createSpinner();
 				genSpinner.start("Generating commit message");
 
-				const commitMessage = await generateCommitMessage({ diff });
+				const context = await getAiEditedOutputsContext("commit");
+				const commitMessage = await generateCommitMessage({ diff, context });
 				genSpinner.stop("Commit message generated");
 
 				p.log.info(`Commit message: ${color.cyan(`"${commitMessage}"`)}`);

--- a/src/lib/ai-edits.ts
+++ b/src/lib/ai-edits.ts
@@ -76,14 +76,26 @@ export interface RecordAiEditedOutputOptions {
 	edited: string;
 }
 
-export function recordAiEditedOutputSession(
+function validateEdits(
 	options: RecordAiEditedOutputOptions,
-): void {
+): { generated: string; edited: string } | null {
 	const generated = options.generated.trim();
 	const edited = options.edited.trim();
 	if (!generated || !edited || generated === edited) {
+		return null;
+	}
+	return { generated, edited };
+}
+
+export function recordAiEditedOutputSession(
+	options: RecordAiEditedOutputOptions,
+): void {
+	const validated = validateEdits(options);
+	if (!validated) {
 		return;
 	}
+
+	const { generated, edited } = validated;
 
 	const last = sessionEntries[0];
 	if (
@@ -113,11 +125,12 @@ export async function recordAiEditedOutput(
 	try {
 		recordAiEditedOutputSession(options);
 
-		const generated = options.generated.trim();
-		const edited = options.edited.trim();
-		if (!generated || !edited || generated === edited) {
+		const validated = validateEdits(options);
+		if (!validated) {
 			return;
 		}
+
+		const { generated, edited } = validated;
 
 		const history = await loadHistory();
 

--- a/src/lib/ai-edits.ts
+++ b/src/lib/ai-edits.ts
@@ -1,0 +1,217 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { git } from "../utils/git";
+
+const CONFIG_DIR = ".oc";
+const HISTORY_FILE = "ai.edits.json";
+const MAX_ENTRIES = 50;
+const MAX_SESSION_ENTRIES = 25;
+
+const sessionEntries: AiEditedOutputEntry[] = [];
+
+export type AiEditedOutputKind =
+	| "branch-name"
+	| "commit-message"
+	| "pr-title"
+	| "pr-body";
+
+export interface AiEditedOutputEntry {
+	timestamp: string;
+	kind: AiEditedOutputKind;
+	generated: string;
+	edited: string;
+}
+
+interface AiEditedOutputHistory {
+	entries: AiEditedOutputEntry[];
+}
+
+async function getRepoRoot(): Promise<string> {
+	return git("rev-parse --show-toplevel");
+}
+
+async function ensureConfigDir(): Promise<string> {
+	const repoRoot = await getRepoRoot();
+	const configDir = join(repoRoot, CONFIG_DIR);
+
+	if (!existsSync(configDir)) {
+		mkdirSync(configDir, { recursive: true });
+	}
+
+	return configDir;
+}
+
+async function getHistoryPath(): Promise<string> {
+	const repoRoot = await getRepoRoot();
+	return join(repoRoot, CONFIG_DIR, HISTORY_FILE);
+}
+
+async function loadHistory(): Promise<AiEditedOutputHistory> {
+	try {
+		const historyPath = await getHistoryPath();
+		if (!existsSync(historyPath)) {
+			return { entries: [] };
+		}
+
+		const content = readFileSync(historyPath, "utf-8");
+		const parsed = JSON.parse(content) as AiEditedOutputHistory;
+		if (!parsed?.entries || !Array.isArray(parsed.entries)) {
+			return { entries: [] };
+		}
+		return parsed;
+	} catch {
+		return { entries: [] };
+	}
+}
+
+async function saveHistory(history: AiEditedOutputHistory): Promise<void> {
+	await ensureConfigDir();
+	const historyPath = await getHistoryPath();
+	writeFileSync(historyPath, JSON.stringify(history, null, 2), "utf-8");
+}
+
+export interface RecordAiEditedOutputOptions {
+	kind: AiEditedOutputKind;
+	generated: string;
+	edited: string;
+}
+
+export function recordAiEditedOutputSession(
+	options: RecordAiEditedOutputOptions,
+): void {
+	const generated = options.generated.trim();
+	const edited = options.edited.trim();
+	if (!generated || !edited || generated === edited) {
+		return;
+	}
+
+	const last = sessionEntries[0];
+	if (
+		last &&
+		last.kind === options.kind &&
+		last.generated === generated &&
+		last.edited === edited
+	) {
+		return;
+	}
+
+	sessionEntries.unshift({
+		timestamp: new Date().toISOString(),
+		kind: options.kind,
+		generated,
+		edited,
+	});
+
+	if (sessionEntries.length > MAX_SESSION_ENTRIES) {
+		sessionEntries.splice(MAX_SESSION_ENTRIES);
+	}
+}
+
+export async function recordAiEditedOutput(
+	options: RecordAiEditedOutputOptions,
+): Promise<void> {
+	try {
+		recordAiEditedOutputSession(options);
+
+		const generated = options.generated.trim();
+		const edited = options.edited.trim();
+		if (!generated || !edited || generated === edited) {
+			return;
+		}
+
+		const history = await loadHistory();
+
+		// De-dupe: if the most recent entry is identical, skip.
+		const last = history.entries[0];
+		if (
+			last &&
+			last.kind === options.kind &&
+			last.generated === generated &&
+			last.edited === edited
+		) {
+			return;
+		}
+
+		history.entries.unshift({
+			timestamp: new Date().toISOString(),
+			kind: options.kind,
+			generated,
+			edited,
+		});
+
+		if (history.entries.length > MAX_ENTRIES) {
+			history.entries = history.entries.slice(0, MAX_ENTRIES);
+		}
+
+		await saveHistory(history);
+	} catch {
+		// Never block the core flow on history persistence.
+	}
+}
+
+function clipForPrompt(value: string, maxChars: number): string {
+	const trimmed = value.trim();
+	if (trimmed.length <= maxChars) {
+		return trimmed;
+	}
+	return `${trimmed.slice(0, maxChars)}\n… (truncated)`;
+}
+
+function formatEntryForPrompt(entry: AiEditedOutputEntry): string {
+	const maxChars = entry.kind === "pr-body" ? 800 : 180;
+	const generated = clipForPrompt(entry.generated, maxChars);
+	const edited = clipForPrompt(entry.edited, maxChars);
+	return `- ${entry.kind}: user edited an AI output\n  - AI: ${JSON.stringify(generated)}\n  - User: ${JSON.stringify(edited)}`;
+}
+
+export type AiEditsContextPurpose = "branch" | "commit" | "pr";
+
+function kindsForPurpose(purpose: AiEditsContextPurpose): AiEditedOutputKind[] {
+	switch (purpose) {
+		case "branch":
+			return ["branch-name"];
+		case "commit":
+			return ["branch-name", "commit-message"];
+		case "pr":
+			return ["commit-message", "pr-title", "pr-body"];
+	}
+}
+
+export async function getAiEditedOutputsContext(
+	purpose: AiEditsContextPurpose,
+): Promise<string | undefined> {
+	try {
+		const kinds = new Set(kindsForPurpose(purpose));
+		const history = await loadHistory();
+
+		const combined = [...sessionEntries, ...history.entries];
+		const seen = new Set<string>();
+		const relevant: AiEditedOutputEntry[] = [];
+
+		for (const entry of combined) {
+			if (!kinds.has(entry.kind)) {
+				continue;
+			}
+			const key = `${entry.kind}\n${entry.generated}\n${entry.edited}`;
+			if (seen.has(key)) {
+				continue;
+			}
+			seen.add(key);
+			relevant.push(entry);
+		}
+
+		if (relevant.length === 0) {
+			return undefined;
+		}
+
+		const maxEntries = purpose === "pr" ? 3 : 5;
+		const lines = relevant.slice(0, maxEntries).map(formatEntryForPrompt);
+
+		return [
+			"User edit history (use this to match the user's preferences):",
+			...lines,
+		].join("\n");
+	} catch {
+		return undefined;
+	}
+}

--- a/src/lib/branch.ts
+++ b/src/lib/branch.ts
@@ -157,7 +157,6 @@ async function resolveBranchName(
 			originalBranchName = branchName;
 			wasEdited = false;
 			p.log.step(`Proposed branch name:\n${color.white(`  "${branchName}"`)}`);
-			continue;
 		}
 	}
 }

--- a/src/lib/branch.ts
+++ b/src/lib/branch.ts
@@ -55,6 +55,15 @@ async function resolveBranchName(
 	let originalBranchName = branchName;
 	let wasEdited = false;
 
+	const recordBranchEdit = (edited: string) => {
+		wasEdited = true;
+		recordAiEditedOutputSession({
+			kind: "branch-name",
+			generated: originalBranchName,
+			edited,
+		});
+	};
+
 	if (yes) {
 		p.log.step(`Proposed branch name:\n${color.white(`  "${branchName}"`)}`);
 		return branchName;
@@ -112,12 +121,7 @@ async function resolveBranchName(
 
 			branchName = replaceBranchIntent(branchName, newIntent as string);
 			branchName = normalizeBranchName(branchName);
-			wasEdited = true;
-			recordAiEditedOutputSession({
-				kind: "branch-name",
-				generated: originalBranchName,
-				edited: branchName,
-			});
+			recordBranchEdit(branchName);
 			p.log.step(`Proposed branch name:\n${color.white(`  "${branchName}"`)}`);
 			continue;
 		}
@@ -137,12 +141,7 @@ async function resolveBranchName(
 			}
 
 			branchName = normalizeBranchName(editedName);
-			wasEdited = true;
-			recordAiEditedOutputSession({
-				kind: "branch-name",
-				generated: originalBranchName,
-				edited: branchName,
-			});
+			recordBranchEdit(branchName);
 			p.log.step(`Proposed branch name:\n${color.white(`  "${branchName}"`)}`);
 			continue;
 		}

--- a/src/lib/opencode.ts
+++ b/src/lib/opencode.ts
@@ -114,6 +114,7 @@ export interface PRGenerationOptions {
 	commits: Array<{ hash: string; message: string }>;
 	targetBranch: string;
 	sourceBranch: string;
+	context?: string;
 }
 
 export interface PRContent {
@@ -418,7 +419,7 @@ function parsePRContent(response: string): PRContent {
 export async function generatePRContent(
 	options: PRGenerationOptions,
 ): Promise<PRContent> {
-	const { diff, commits, targetBranch, sourceBranch } = options;
+	const { diff, commits, targetBranch, sourceBranch, context } = options;
 
 	const systemPrompt = await getPRConfig();
 	const prModel = await getPRModel();
@@ -436,6 +437,10 @@ export async function generatePRContent(
 	}
 
 	prompt += `## Diff\n\n\`\`\`diff\n${diff}\n\`\`\``;
+
+	if (context) {
+		prompt += `\n\nAdditional context:\n${context}`;
+	}
 
 	const { message, close } = await runOpencodePrompt({
 		title: "oc-pr",

--- a/src/lib/pr.ts
+++ b/src/lib/pr.ts
@@ -18,6 +18,11 @@ import {
 	replaceCommitIntent,
 } from "../utils/intent";
 import { getConfig } from "./config";
+import {
+	getAiEditedOutputsContext,
+	recordAiEditedOutput,
+	recordAiEditedOutputSession,
+} from "./ai-edits";
 import { generatePRContent, type PRContent } from "./opencode";
 import { createSpinner, isInteractiveMode } from "../utils/ui";
 
@@ -212,6 +217,8 @@ async function resolvePRContent(
 	const s = createSpinner();
 	s.start("Generating PR title and description");
 
+	const context = await getAiEditedOutputsContext("pr");
+
 	let prContent: PRContent;
 	try {
 		prContent = await generatePRContent({
@@ -219,12 +226,17 @@ async function resolvePRContent(
 			commits,
 			sourceBranch,
 			targetBranch,
+			context,
 		});
 		s.stop("PR content generated");
 	} catch (error) {
 		s.stop("Failed to generate PR content");
 		throw error;
 	}
+
+	let originalTitle = prContent.title;
+	let originalBody = prContent.body;
+	let wasEdited = false;
 
 	if (yes) {
 		p.log.step(`Proposed PR title:\n${color.white(`  "${prContent.title}"`)}`);
@@ -269,6 +281,22 @@ async function resolvePRContent(
 		}
 
 		if (action === "create") {
+			if (wasEdited) {
+				if (prContent.title.trim() !== originalTitle.trim()) {
+					await recordAiEditedOutput({
+						kind: "pr-title",
+						generated: originalTitle,
+						edited: prContent.title,
+					});
+				}
+				if (prContent.body.trim() !== originalBody.trim()) {
+					await recordAiEditedOutput({
+						kind: "pr-body",
+						generated: originalBody,
+						edited: prContent.body,
+					});
+				}
+			}
 			return prContent;
 		}
 
@@ -284,9 +312,16 @@ async function resolvePRContent(
 				prContent.title,
 				newIntent as string,
 			);
+			wasEdited = true;
+			recordAiEditedOutputSession({
+				kind: "pr-title",
+				generated: originalTitle,
+				edited: prContent.title,
+			});
 			p.log.step(
 				`Proposed PR title:\n${color.white(`  "${prContent.title}"`)}`,
 			);
+			p.log.step(`Proposed PR body:\n${color.dim(prContent.body)}`);
 			continue;
 		}
 
@@ -316,6 +351,23 @@ async function resolvePRContent(
 				title: editedTitle,
 				body: editedBody || "",
 			};
+			wasEdited = true;
+
+			if (prContent.title.trim() !== originalTitle.trim()) {
+				recordAiEditedOutputSession({
+					kind: "pr-title",
+					generated: originalTitle,
+					edited: prContent.title,
+				});
+			}
+			if (prContent.body.trim() !== originalBody.trim()) {
+				recordAiEditedOutputSession({
+					kind: "pr-body",
+					generated: originalBody,
+					edited: prContent.body,
+				});
+			}
+
 			p.log.step(
 				`Proposed PR title:\n${color.white(`  "${prContent.title}"`)}`,
 			);
@@ -333,8 +385,12 @@ async function resolvePRContent(
 					commits,
 					sourceBranch,
 					targetBranch,
+					context,
 				});
 				regenSpinner.stop("PR content regenerated");
+				originalTitle = prContent.title;
+				originalBody = prContent.body;
+				wasEdited = false;
 			} catch (error) {
 				regenSpinner.stop("Failed to regenerate PR content");
 				throw error;

--- a/src/lib/pr.ts
+++ b/src/lib/pr.ts
@@ -398,7 +398,6 @@ async function resolvePRContent(
 				`Proposed PR title:\n${color.white(`  "${prContent.title}"`)}`,
 			);
 			p.log.step(`Proposed PR body:\n${color.dim(prContent.body)}`);
-			continue;
 		}
 	}
 }

--- a/src/lib/pr.ts
+++ b/src/lib/pr.ts
@@ -238,6 +238,24 @@ async function resolvePRContent(
 	let originalBody = prContent.body;
 	let wasEdited = false;
 
+	const recordPREdit = (title: string, body: string) => {
+		wasEdited = true;
+		if (title.trim() !== originalTitle.trim()) {
+			recordAiEditedOutputSession({
+				kind: "pr-title",
+				generated: originalTitle,
+				edited: title,
+			});
+		}
+		if (body.trim() !== originalBody.trim()) {
+			recordAiEditedOutputSession({
+				kind: "pr-body",
+				generated: originalBody,
+				edited: body,
+			});
+		}
+	};
+
 	if (yes) {
 		p.log.step(`Proposed PR title:\n${color.white(`  "${prContent.title}"`)}`);
 		p.log.step(`Proposed PR body:\n${color.dim(prContent.body)}`);
@@ -312,12 +330,7 @@ async function resolvePRContent(
 				prContent.title,
 				newIntent as string,
 			);
-			wasEdited = true;
-			recordAiEditedOutputSession({
-				kind: "pr-title",
-				generated: originalTitle,
-				edited: prContent.title,
-			});
+			recordPREdit(prContent.title, prContent.body);
 			p.log.step(
 				`Proposed PR title:\n${color.white(`  "${prContent.title}"`)}`,
 			);
@@ -351,22 +364,7 @@ async function resolvePRContent(
 				title: editedTitle,
 				body: editedBody || "",
 			};
-			wasEdited = true;
-
-			if (prContent.title.trim() !== originalTitle.trim()) {
-				recordAiEditedOutputSession({
-					kind: "pr-title",
-					generated: originalTitle,
-					edited: prContent.title,
-				});
-			}
-			if (prContent.body.trim() !== originalBody.trim()) {
-				recordAiEditedOutputSession({
-					kind: "pr-body",
-					generated: originalBody,
-					edited: prContent.body,
-				});
-			}
+			recordPREdit(prContent.title, prContent.body);
 
 			p.log.step(
 				`Proposed PR title:\n${color.white(`  "${prContent.title}"`)}`,


### PR DESCRIPTION
## Summary

Introduce AI-edits history and context feeding to AI-generated prompts. Enables context-aware generation for branch names, commit messages, and PR content, while persisting user-edits locally under the .oc directory.

## Changes

- Add new AI edits module at `src/lib/ai-edits.ts` to record and retrieve user-edited AI outputs, persist history to `.oc/ai.edits.json`, and provide `getAiEditedOutputsContext` for context injection.
- Wire AI edit context into commit flow:
  - Import and use `getAiEditedOutputsContext` in `src/commands/commit.ts` and pass context to AI-generated commit messages.
  - Record edited commit messages via `recordAiEditedOutput` and `recordAiEditedOutputSession`.
- Wire AI edit context into release flow:
  - Use context when generating commit messages for releases in `src/commands/release.ts`.
- Wire AI edit context into branch flow:
  - Pass context to branch name generation in `src/lib/branch.ts` and record edits.
- Wire AI edit context into PR flow:
  - Pass context to PR content generation in `src/lib/pr.ts`.
  - Record edited PR title/body via `recordAiEditedOutput` and `recordAiEditedOutputSession`.
- Extend PR content generation:
  - Update `src/lib/opencode.ts` to accept an optional `context` and append it to the prompt.
- UI/UX tweaks:
  - Update `src/utils/confirm.ts` to consolidate confirm-each and interactive modes into a single interactive flow.
- CI/local-history:
  - Update `.gitignore` to include ocmt local history files (`.oc/changelog.history.json`, `.oc/ai.edits.json`).

## Testing

- Trigger AI-generated prompts for commit/branch/PR, then edit the outputs and ensure edits are persisted in:
  - `.oc/ai.edits.json` (history)
  - Per-session records via in-memory session cache during the session
- Verify regenerated prompts use previous edits when available.
- Validate builds and type checks with `bun run check` or `mise run build` as per project guidelines.
- Manual sanity checks:
  - Run a commit with AI-generated message, simulate edits, and confirm edits are tracked.
  - Generate a PR with AI-generated title/body, edit, and confirm edits are recorded.