### PR TITLE
refactor: consolidate interactive content workflows

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -9,7 +9,7 @@ import {
 } from "../lib/ai-edits";
 import { cleanup, generateCommitMessage } from "../lib/opencode";
 import { maybeCreatePRAfterCommit } from "../lib/pr";
-import { confirmAction, confirmWithMode } from "../utils/confirm";
+import { confirmAction } from "../utils/confirm";
 import {
 	commit,
 	type GitStatus,
@@ -25,6 +25,7 @@ import {
 	replaceCommitIntent,
 } from "../utils/intent";
 import { createSpinner } from "../utils/ui";
+import { interactiveContentLoop } from "../utils/interactive-content";
 
 export interface CommitOptions {
 	message?: string;
@@ -124,11 +125,9 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
 	// If message provided, use it directly
 	let commitMessage = options.message;
 	let originalCommitMessage: string | null = null;
-	let wasEdited = false;
 
 	const recordCommitEdit = (edited: string) => {
 		if (originalCommitMessage) {
-			wasEdited = true;
 			recordAiEditedOutputSession({
 				kind: "commit-message",
 				generated: originalCommitMessage,
@@ -152,7 +151,6 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
 			});
 			s.stop("Commit message generated");
 			originalCommitMessage = commitMessage;
-			wasEdited = false;
 		} catch (error) {
 			s.stop("Failed to generate commit message");
 			p.cancel(error instanceof Error ? error.message : String(error));
@@ -163,123 +161,94 @@ export async function commitCommand(options: CommitOptions): Promise<void> {
 
 	// Confirm commit (unless --yes or --accept)
 	if (!options.yes && !options.accept) {
-		// Check mode-aware confirmation first
-		const confirmResult = await confirmWithMode({
+		const result = await interactiveContentLoop({
 			content: commitMessage,
 			contentLabel: "Proposed commit message",
+			displayContent: (message) => {
+				p.log.step(
+					`Proposed commit message:\n${color.white(`  "${message}"`)}`,
+				);
+			},
+			onEdit: async (current) => {
+				const editedMessage = await p.text({
+					message: "Enter commit message:",
+					initialValue: current,
+					validate: (value) => {
+						if (!value.trim()) return "Commit message cannot be empty";
+					},
+				});
+
+				if (p.isCancel(editedMessage)) {
+					return null;
+				}
+
+				recordCommitEdit(editedMessage);
+				return editedMessage;
+			},
+			onIntent: async (current) => {
+				const currentIntent = detectCommitIntent(current);
+				const newIntent = await promptForIntent(currentIntent);
+
+				if (p.isCancel(newIntent)) {
+					return null;
+				}
+
+				const updated = replaceCommitIntent(current, newIntent as string);
+				recordCommitEdit(updated);
+				return updated;
+			},
+			onRegenerate: async () => {
+				const s = createSpinner();
+				s.start("Regenerating commit message");
+
+				const context = await getAiEditedOutputsContext("commit");
+
+				try {
+					const regenerated = await generateCommitMessage({
+						diff,
+						context,
+						modelOverride: options.model,
+					});
+					s.stop("Commit message regenerated");
+					originalCommitMessage = regenerated;
+					return regenerated;
+				} catch (error) {
+					s.stop("Failed to regenerate commit message");
+					p.cancel(error instanceof Error ? error.message : String(error));
+					cleanup();
+					process.exit(1);
+				}
+			},
+			trackEdit: async (generated, edited) => {
+				if (!originalCommitMessage) {
+					return;
+				}
+				if (edited.trim() !== generated.trim()) {
+					await recordAiEditedOutput({
+						kind: "commit-message",
+						generated,
+						edited,
+					});
+				}
+			},
+			primaryActionLabel: "Commit with this message",
+			skipLabel: "Skip commit",
+			editLabel: "Edit message",
+			regenerateLabel: "Regenerate message",
 		});
 
-		if (confirmResult === "cancel") {
+		if (result === null) {
 			p.cancel("Aborted");
 			cleanup();
 			process.exit(0);
 		}
 
-		// Only enter full action loop if mode returned "interactive"
-		if (confirmResult === "interactive") {
-			let actionLoop = true;
-			while (actionLoop) {
-				const action = await p.select({
-					message: "What would you like to do?",
-					options: [
-						{ value: "commit", label: "Commit with this message" },
-						{ value: "intent", label: "Change intent" },
-						{ value: "edit", label: "Edit message" },
-						{ value: "regenerate", label: "Regenerate message" },
-						{ value: "cancel", label: "Cancel" },
-					],
-				});
-
-				if (p.isCancel(action) || action === "cancel") {
-					p.cancel("Aborted");
-					cleanup();
-					process.exit(0);
-				}
-
-				if (action === "commit") {
-					if (
-						originalCommitMessage &&
-						wasEdited &&
-						commitMessage.trim() !== originalCommitMessage.trim()
-					) {
-						await recordAiEditedOutput({
-							kind: "commit-message",
-							generated: originalCommitMessage,
-							edited: commitMessage,
-						});
-					}
-					actionLoop = false;
-					break;
-				}
-
-				if (action === "intent") {
-					const currentIntent = detectCommitIntent(commitMessage);
-					const newIntent = await promptForIntent(currentIntent);
-
-					if (p.isCancel(newIntent)) {
-						continue;
-					}
-
-					commitMessage = replaceCommitIntent(
-						commitMessage,
-						newIntent as string,
-					);
-					recordCommitEdit(commitMessage);
-					p.log.step(
-						`Proposed commit message:\n${color.white(`  "${commitMessage}"`)}`,
-					);
-					continue;
-				}
-
-				if (action === "edit") {
-					const editedMessage = await p.text({
-						message: "Enter commit message:",
-						initialValue: commitMessage,
-						validate: (value) => {
-							if (!value.trim()) return "Commit message cannot be empty";
-						},
-					});
-
-					if (p.isCancel(editedMessage)) {
-						continue;
-					}
-
-					commitMessage = editedMessage;
-					recordCommitEdit(commitMessage);
-					p.log.step(
-						`Proposed commit message:\n${color.white(`  "${commitMessage}"`)}`,
-					);
-					continue;
-				}
-
-				if (action === "regenerate") {
-					const s = createSpinner();
-					s.start("Regenerating commit message");
-
-					const context = await getAiEditedOutputsContext("commit");
-
-					try {
-						commitMessage = await generateCommitMessage({
-							diff,
-							context,
-							modelOverride: options.model,
-						});
-						s.stop("Commit message regenerated");
-						originalCommitMessage = commitMessage;
-						wasEdited = false;
-					} catch (error) {
-						s.stop("Failed to regenerate commit message");
-						p.cancel(error instanceof Error ? error.message : String(error));
-						cleanup();
-						process.exit(1);
-					}
-
-					p.log.step(
-						`Proposed commit message:\n${color.white(`  "${commitMessage}"`)}`,
-					);
-				}
-			}
+		if (result === "skip") {
+			cleanup();
+			process.exit(0);
 		}
+
+		commitMessage = result;
 	} else {
 		// Show the commit message when using --yes or --accept
 		p.log.step(

--- a/src/lib/branch.ts
+++ b/src/lib/branch.ts
@@ -1,6 +1,6 @@
 import * as p from "@clack/prompts";
 import color from "picocolors";
-import { confirmAction, confirmWithMode } from "../utils/confirm";
+import { confirmAction } from "../utils/confirm";
 import {
 	branchExists,
 	createBranch,
@@ -20,6 +20,7 @@ import {
 } from "./ai-edits";
 import { generateBranchName } from "./opencode";
 import { createSpinner } from "../utils/ui";
+import { interactiveContentLoop } from "../utils/interactive-content";
 
 export type BranchFlowResult = "continue" | "abort";
 
@@ -42,7 +43,7 @@ function normalizeBranchName(name: string): string {
 async function resolveBranchName(
 	diff: string,
 	yes?: boolean,
-): Promise<string | null> {
+): Promise<string | null | "skip"> {
 	const s = createSpinner();
 	s.start("Generating branch name");
 
@@ -53,10 +54,8 @@ async function resolveBranchName(
 
 	branchName = normalizeBranchName(branchName);
 	let originalBranchName = branchName;
-	let wasEdited = false;
 
 	const recordBranchEdit = (edited: string) => {
-		wasEdited = true;
 		recordAiEditedOutputSession({
 			kind: "branch-name",
 			generated: originalBranchName,
@@ -64,72 +63,16 @@ async function resolveBranchName(
 		});
 	};
 
-	if (yes) {
-		p.log.step(`Proposed branch name:\n${color.white(`  "${branchName}"`)}`);
-		return branchName;
-	}
-
-	// Check mode-aware confirmation first
-	const confirmResult = await confirmWithMode({
+	const result = await interactiveContentLoop({
 		content: branchName,
 		contentLabel: "Proposed branch name",
-	});
-
-	if (confirmResult === "cancel") {
-		return null;
-	}
-
-	if (confirmResult === "accept") {
-		return branchName;
-	}
-
-	// Interactive mode - full action loop
-	while (true) {
-		const action = await p.select({
-			message: "What would you like to do?",
-			options: [
-				{ value: "create", label: "Create branch with this name" },
-				{ value: "intent", label: "Change intent" },
-				{ value: "edit", label: "Edit name" },
-				{ value: "regenerate", label: "Regenerate name" },
-				{ value: "cancel", label: "Cancel" },
-			],
-		});
-
-		if (p.isCancel(action) || action === "cancel") {
-			return null;
-		}
-
-		if (action === "create") {
-			if (wasEdited && branchName.trim() !== originalBranchName.trim()) {
-				await recordAiEditedOutput({
-					kind: "branch-name",
-					generated: originalBranchName,
-					edited: branchName,
-				});
-			}
-			return branchName;
-		}
-
-		if (action === "intent") {
-			const currentIntent = detectBranchIntent(branchName);
-			const newIntent = await promptForIntent(currentIntent);
-
-			if (p.isCancel(newIntent)) {
-				continue;
-			}
-
-			branchName = replaceBranchIntent(branchName, newIntent as string);
-			branchName = normalizeBranchName(branchName);
-			recordBranchEdit(branchName);
-			p.log.step(`Proposed branch name:\n${color.white(`  "${branchName}"`)}`);
-			continue;
-		}
-
-		if (action === "edit") {
+		displayContent: (name) => {
+			p.log.step(`Proposed branch name:\n${color.white(`  "${name}"`)}`);
+		},
+		onEdit: async (current) => {
 			const editedName = await p.text({
 				message: "Enter branch name:",
-				initialValue: branchName,
+				initialValue: current,
 				validate: (value) => {
 					if (!value.trim()) return "Branch name cannot be empty";
 					if (/\s/.test(value)) return "Branch name cannot contain spaces";
@@ -137,28 +80,55 @@ async function resolveBranchName(
 			});
 
 			if (p.isCancel(editedName)) {
-				continue;
+				return null;
 			}
 
-			branchName = normalizeBranchName(editedName);
-			recordBranchEdit(branchName);
-			p.log.step(`Proposed branch name:\n${color.white(`  "${branchName}"`)}`);
-			continue;
-		}
+			const normalized = normalizeBranchName(editedName);
+			recordBranchEdit(normalized);
+			return normalized;
+		},
+		onIntent: async (current) => {
+			const currentIntent = detectBranchIntent(current);
+			const newIntent = await promptForIntent(currentIntent);
 
-		if (action === "regenerate") {
+			if (p.isCancel(newIntent)) {
+				return null;
+			}
+
+			const updated = normalizeBranchName(
+				replaceBranchIntent(current, newIntent as string),
+			);
+			recordBranchEdit(updated);
+			return updated;
+		},
+		onRegenerate: async () => {
 			const regenSpinner = createSpinner();
 			regenSpinner.start("Regenerating branch name");
 
-			branchName = await generateBranchName({ diff, context });
+			const regenerated = await generateBranchName({ diff, context });
 			regenSpinner.stop("Branch name regenerated");
 
-			branchName = normalizeBranchName(branchName);
-			originalBranchName = branchName;
-			wasEdited = false;
-			p.log.step(`Proposed branch name:\n${color.white(`  "${branchName}"`)}`);
-		}
-	}
+			const normalized = normalizeBranchName(regenerated);
+			originalBranchName = normalized;
+			return normalized;
+		},
+		trackEdit: async (generated, edited) => {
+			if (edited.trim() !== generated.trim()) {
+				await recordAiEditedOutput({
+					kind: "branch-name",
+					generated,
+					edited,
+				});
+			}
+		},
+		primaryActionLabel: "Create branch with this name",
+		skipLabel: "Skip new branch",
+		editLabel: "Edit name",
+		regenerateLabel: "Regenerate name",
+		yes,
+	});
+
+	return result;
 }
 
 async function ensureUniqueBranchName(
@@ -243,7 +213,7 @@ export async function maybeCreateBranchForCommit(
 	}
 
 	// Use provided branch name or generate one
-	let branchName: string | null = null;
+	let branchName: string | null | "skip" = null;
 	if (providedBranchName) {
 		branchName = normalizeBranchName(providedBranchName);
 	} else {
@@ -255,6 +225,9 @@ export async function maybeCreateBranchForCommit(
 		}
 	}
 	if (!branchName) return "abort";
+	if (branchName === "skip") {
+		return "continue";
+	}
 
 	branchName = await ensureUniqueBranchName(branchName, yes);
 	if (!branchName) return "abort";

--- a/src/lib/pr.ts
+++ b/src/lib/pr.ts
@@ -2,7 +2,7 @@ import { exec, execFile } from "node:child_process";
 import { promisify } from "node:util";
 import * as p from "@clack/prompts";
 import color from "picocolors";
-import { confirmAction, confirmWithMode } from "../utils/confirm";
+import { confirmAction } from "../utils/confirm";
 import {
 	getCommitsFromBranch,
 	getCurrentBranch,
@@ -25,6 +25,7 @@ import {
 } from "./ai-edits";
 import { generatePRContent, type PRContent } from "./opencode";
 import { createSpinner, isInteractiveMode } from "../utils/ui";
+import { interactiveContentLoop } from "../utils/interactive-content";
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -236,10 +237,8 @@ async function resolvePRContent(
 
 	let originalTitle = prContent.title;
 	let originalBody = prContent.body;
-	let wasEdited = false;
 
 	const recordPREdit = (title: string, body: string) => {
-		wasEdited = true;
 		if (title.trim() !== originalTitle.trim()) {
 			recordAiEditedOutputSession({
 				kind: "pr-title",
@@ -256,129 +255,64 @@ async function resolvePRContent(
 		}
 	};
 
-	if (yes) {
-		p.log.step(`Proposed PR title:\n${color.white(`  "${prContent.title}"`)}`);
-		p.log.step(`Proposed PR body:\n${color.dim(prContent.body)}`);
-		return prContent;
-	}
-
-	// Check mode-aware confirmation (content will be displayed by confirmWithMode)
-	// But for PR we have both title and body, so display them first
-	p.log.step(`Proposed PR title:\n${color.white(`  "${prContent.title}"`)}`);
-	p.log.step(`Proposed PR body:\n${color.dim(prContent.body)}`);
-
-	const confirmResult = await confirmWithMode({
-		content: prContent.title,
+	const result = await interactiveContentLoop({
+		content: prContent,
 		contentLabel: "PR content",
-		skipDisplay: true, // Already displayed above
-	});
-
-	if (confirmResult === "cancel") {
-		return null;
-	}
-
-	if (confirmResult === "accept") {
-		return prContent;
-	}
-
-	// Interactive mode - full action loop
-	while (true) {
-		const action = await p.select({
-			message: "What would you like to do?",
-			options: [
-				{ value: "create", label: "Create PR with this content" },
-				{ value: "intent", label: "Change intent" },
-				{ value: "edit", label: "Edit content" },
-				{ value: "regenerate", label: "Regenerate content" },
-				{ value: "cancel", label: "Cancel" },
-			],
-		});
-
-		if (p.isCancel(action) || action === "cancel") {
-			return null;
-		}
-
-		if (action === "create") {
-			if (wasEdited) {
-				if (prContent.title.trim() !== originalTitle.trim()) {
-					await recordAiEditedOutput({
-						kind: "pr-title",
-						generated: originalTitle,
-						edited: prContent.title,
-					});
-				}
-				if (prContent.body.trim() !== originalBody.trim()) {
-					await recordAiEditedOutput({
-						kind: "pr-body",
-						generated: originalBody,
-						edited: prContent.body,
-					});
-				}
-			}
-			return prContent;
-		}
-
-		if (action === "intent") {
-			const currentIntent = detectCommitIntent(prContent.title);
+		confirmContent: prContent.title,
+		displayContent: (content) => {
+			p.log.step(`Proposed PR title:\n${color.white(`  "${content.title}"`)}`);
+			p.log.step(`Proposed PR body:\n${color.dim(content.body)}`);
+		},
+		onIntent: async (current) => {
+			const currentIntent = detectCommitIntent(current.title);
 			const newIntent = await promptForIntent(currentIntent);
 
 			if (p.isCancel(newIntent)) {
-				continue;
+				return null;
 			}
 
-			prContent.title = replaceCommitIntent(
-				prContent.title,
-				newIntent as string,
-			);
-			recordPREdit(prContent.title, prContent.body);
-			p.log.step(
-				`Proposed PR title:\n${color.white(`  "${prContent.title}"`)}`,
-			);
-			p.log.step(`Proposed PR body:\n${color.dim(prContent.body)}`);
-			continue;
-		}
-
-		if (action === "edit") {
+			const updated = {
+				...current,
+				title: replaceCommitIntent(current.title, newIntent as string),
+			};
+			recordPREdit(updated.title, updated.body);
+			return updated;
+		},
+		onEdit: async (current) => {
 			const editedTitle = await p.text({
 				message: "Enter PR title:",
-				initialValue: prContent.title,
+				initialValue: current.title,
 				validate: (value) => {
 					if (!value.trim()) return "PR title cannot be empty";
 				},
 			});
 
 			if (p.isCancel(editedTitle)) {
-				continue;
+				return null;
 			}
 
 			const editedBody = await p.text({
 				message: "Enter PR body:",
-				initialValue: prContent.body,
+				initialValue: current.body,
 			});
 
 			if (p.isCancel(editedBody)) {
-				continue;
+				return null;
 			}
 
-			prContent = {
+			const updated = {
 				title: editedTitle,
 				body: editedBody || "",
 			};
-			recordPREdit(prContent.title, prContent.body);
-
-			p.log.step(
-				`Proposed PR title:\n${color.white(`  "${prContent.title}"`)}`,
-			);
-			p.log.step(`Proposed PR body:\n${color.dim(prContent.body)}`);
-			continue;
-		}
-
-		if (action === "regenerate") {
+			recordPREdit(updated.title, updated.body);
+			return updated;
+		},
+		onRegenerate: async () => {
 			const regenSpinner = createSpinner();
 			regenSpinner.start("Regenerating PR content");
 
 			try {
-				prContent = await generatePRContent({
+				const regenerated = await generatePRContent({
 					diff,
 					commits,
 					sourceBranch,
@@ -386,20 +320,41 @@ async function resolvePRContent(
 					context,
 				});
 				regenSpinner.stop("PR content regenerated");
-				originalTitle = prContent.title;
-				originalBody = prContent.body;
-				wasEdited = false;
+				originalTitle = regenerated.title;
+				originalBody = regenerated.body;
+				return regenerated;
 			} catch (error) {
 				regenSpinner.stop("Failed to regenerate PR content");
 				throw error;
 			}
+		},
+		trackEdit: async (_generated, edited) => {
+			if (edited.title.trim() !== originalTitle.trim()) {
+				await recordAiEditedOutput({
+					kind: "pr-title",
+					generated: originalTitle,
+					edited: edited.title,
+				});
+			}
+			if (edited.body.trim() !== originalBody.trim()) {
+				await recordAiEditedOutput({
+					kind: "pr-body",
+					generated: originalBody,
+					edited: edited.body,
+				});
+			}
+		},
+		primaryActionLabel: "Create PR with this content",
+		editLabel: "Edit content",
+		regenerateLabel: "Regenerate content",
+		yes,
+	});
 
-			p.log.step(
-				`Proposed PR title:\n${color.white(`  "${prContent.title}"`)}`,
-			);
-			p.log.step(`Proposed PR body:\n${color.dim(prContent.body)}`);
-		}
+	if (result === "skip") {
+		return null;
 	}
+
+	return result;
 }
 
 async function ensureBranchPushed(): Promise<boolean> {

--- a/src/utils/interactive-content.ts
+++ b/src/utils/interactive-content.ts
@@ -1,0 +1,132 @@
+import * as p from "@clack/prompts";
+import { confirmWithMode } from "./confirm";
+
+export type ActionLoopResult<T> = T | "skip" | null;
+
+export interface ActionLoopConfig<T> {
+	content: T;
+	contentLabel: string;
+	confirmContent?: string;
+	displayContent: (content: T) => void;
+	onEdit?: (current: T) => Promise<T | null>;
+	onIntent?: (current: T) => Promise<T | null>;
+	onRegenerate?: () => Promise<T>;
+	trackEdit?: (generated: T, edited: T) => void | Promise<void>;
+	primaryActionLabel: string;
+	skipLabel?: string;
+	intentLabel?: string;
+	editLabel?: string;
+	regenerateLabel?: string;
+	yes?: boolean;
+	skipInitialDisplay?: boolean;
+}
+
+export async function interactiveContentLoop<T>(
+	config: ActionLoopConfig<T>,
+): Promise<ActionLoopResult<T>> {
+	const confirmContent =
+		config.confirmContent ??
+		(typeof config.content === "string"
+			? config.content
+			: config.contentLabel);
+	const shouldDisplay = !config.skipInitialDisplay;
+
+	if (shouldDisplay) {
+		config.displayContent(config.content);
+	}
+
+	if (config.yes) {
+		return config.content;
+	}
+
+	const confirmResult = await confirmWithMode({
+		content: confirmContent,
+		contentLabel: config.contentLabel,
+		skipDisplay: shouldDisplay,
+	});
+
+	if (confirmResult === "cancel") {
+		return null;
+	}
+
+	if (confirmResult === "accept") {
+		return config.content;
+	}
+
+	let current = config.content;
+	let generated = config.content;
+	let wasEdited = false;
+
+	const intentLabel = config.intentLabel ?? "Change intent";
+	const editLabel = config.editLabel ?? "Edit content";
+	const regenerateLabel = config.regenerateLabel ?? "Regenerate content";
+
+	while (true) {
+		const options: Array<{ value: string; label: string }> = [
+			{ value: "primary", label: config.primaryActionLabel },
+		];
+
+		if (config.onIntent) {
+			options.push({ value: "intent", label: intentLabel });
+		}
+		if (config.onEdit) {
+			options.push({ value: "edit", label: editLabel });
+		}
+		if (config.onRegenerate) {
+			options.push({ value: "regenerate", label: regenerateLabel });
+		}
+		if (config.skipLabel) {
+			options.push({ value: "skip", label: config.skipLabel });
+		}
+
+		options.push({ value: "cancel", label: "Cancel" });
+
+		const action = await p.select({
+			message: "What would you like to do?",
+			options,
+		});
+
+		if (p.isCancel(action) || action === "cancel") {
+			return null;
+		}
+
+		if (action === "skip") {
+			return "skip";
+		}
+
+		if (action === "primary") {
+			if (wasEdited && config.trackEdit) {
+				await config.trackEdit(generated, current);
+			}
+			return current;
+		}
+
+		if (action === "intent" && config.onIntent) {
+			const result = await config.onIntent(current);
+			if (result !== null) {
+				current = result;
+				wasEdited = true;
+				config.displayContent(current);
+			}
+			continue;
+		}
+
+		if (action === "edit" && config.onEdit) {
+			const result = await config.onEdit(current);
+			if (result !== null) {
+				current = result;
+				wasEdited = true;
+				config.displayContent(current);
+			}
+			continue;
+		}
+
+		if (action === "regenerate" && config.onRegenerate) {
+			current = await config.onRegenerate();
+			generated = current;
+			wasEdited = false;
+			config.displayContent(current);
+			continue;
+		}
+	}
+}


### PR DESCRIPTION
Added a shared interactive content loop with skip support, then refactored branch/commit/PR flows to use it so “Skip” cleanly continues while “Cancel” aborts. Branch and commit now show explicit skip options, and the PR flow uses the same DRY loop for consistency. Changes are in src/utils/interactive-content.ts, src/lib/branch.ts, src/commands/commit.ts, and src/lib/pr.ts.