### PR TITLE
Ian/global ai edits

### DIFF
--- a/src/lib/ai-edits.ts
+++ b/src/lib/ai-edits.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { git } from "../utils/git";
+import { getConfig } from "./config";
 
 const CONFIG_DIR = ".oc";
 const HISTORY_FILE = "ai.edits.json";
@@ -32,6 +33,17 @@ async function getRepoRoot(): Promise<string> {
 	return git("rev-parse --show-toplevel");
 }
 
+async function ensureConfigDir(): Promise<string> {
+	const repoRoot = await getRepoRoot();
+	const configDir = join(repoRoot, CONFIG_DIR);
+
+	if (!existsSync(configDir)) {
+		mkdirSync(configDir, { recursive: true });
+	}
+
+	return configDir;
+}
+
 async function getLocalHistoryPath(): Promise<string> {
 	const repoRoot = await getRepoRoot();
 	return join(repoRoot, CONFIG_DIR, HISTORY_FILE);
@@ -45,15 +57,24 @@ async function getGlobalHistoryPath(): Promise<string> {
 
 async function loadHistory(): Promise<AiEditedOutputHistory> {
 	try {
+		const config = await getConfig();
+		const storage = config.aiEdits?.storage || "local";
+
 		const globalPath = await getGlobalHistoryPath();
 		const localPath = await getLocalHistoryPath();
 
 		let historyPath: string | undefined;
 
-		if (existsSync(globalPath)) {
-			historyPath = globalPath;
-		} else if (existsSync(localPath)) {
-			historyPath = localPath;
+		if (storage === "global") {
+			if (existsSync(globalPath)) {
+				historyPath = globalPath;
+			} else if (existsSync(localPath)) {
+				historyPath = localPath;
+			}
+		} else {
+			if (existsSync(localPath)) {
+				historyPath = localPath;
+			}
 		}
 
 		if (!historyPath) {
@@ -72,14 +93,23 @@ async function loadHistory(): Promise<AiEditedOutputHistory> {
 }
 
 async function saveHistory(history: AiEditedOutputHistory): Promise<void> {
-	const historyPath = await getGlobalHistoryPath();
-	const historyDir = dirname(historyPath);
+	const config = await getConfig();
+	const storage = config.aiEdits?.storage || "local";
 
-	if (!existsSync(historyDir)) {
-		mkdirSync(historyDir, { recursive: true });
+	if (storage === "global") {
+		const historyPath = await getGlobalHistoryPath();
+		const historyDir = dirname(historyPath);
+
+		if (!existsSync(historyDir)) {
+			mkdirSync(historyDir, { recursive: true });
+		}
+
+		writeFileSync(historyPath, JSON.stringify(history, null, 2), "utf-8");
+	} else {
+		await ensureConfigDir();
+		const historyPath = await getLocalHistoryPath();
+		writeFileSync(historyPath, JSON.stringify(history, null, 2), "utf-8");
 	}
-
-	writeFileSync(historyPath, JSON.stringify(history, null, 2), "utf-8");
 }
 
 export interface RecordAiEditedOutputOptions {

--- a/src/lib/ai-edits.ts
+++ b/src/lib/ai-edits.ts
@@ -1,5 +1,7 @@
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import { git } from "../utils/git";
 
 const CONFIG_DIR = ".oc";
@@ -30,26 +32,31 @@ async function getRepoRoot(): Promise<string> {
 	return git("rev-parse --show-toplevel");
 }
 
-async function ensureConfigDir(): Promise<string> {
-	const repoRoot = await getRepoRoot();
-	const configDir = join(repoRoot, CONFIG_DIR);
-
-	if (!existsSync(configDir)) {
-		mkdirSync(configDir, { recursive: true });
-	}
-
-	return configDir;
-}
-
-async function getHistoryPath(): Promise<string> {
+async function getLocalHistoryPath(): Promise<string> {
 	const repoRoot = await getRepoRoot();
 	return join(repoRoot, CONFIG_DIR, HISTORY_FILE);
 }
 
+async function getGlobalHistoryPath(): Promise<string> {
+	const repoRoot = await getRepoRoot();
+	const hash = createHash("sha256").update(repoRoot).digest("hex");
+	return join(homedir(), ".ocmt", "oc", "ai-edits", `${hash}.json`);
+}
+
 async function loadHistory(): Promise<AiEditedOutputHistory> {
 	try {
-		const historyPath = await getHistoryPath();
-		if (!existsSync(historyPath)) {
+		const globalPath = await getGlobalHistoryPath();
+		const localPath = await getLocalHistoryPath();
+
+		let historyPath: string | undefined;
+
+		if (existsSync(globalPath)) {
+			historyPath = globalPath;
+		} else if (existsSync(localPath)) {
+			historyPath = localPath;
+		}
+
+		if (!historyPath) {
 			return { entries: [] };
 		}
 
@@ -65,8 +72,13 @@ async function loadHistory(): Promise<AiEditedOutputHistory> {
 }
 
 async function saveHistory(history: AiEditedOutputHistory): Promise<void> {
-	await ensureConfigDir();
-	const historyPath = await getHistoryPath();
+	const historyPath = await getGlobalHistoryPath();
+	const historyDir = dirname(historyPath);
+
+	if (!existsSync(historyDir)) {
+		mkdirSync(historyDir, { recursive: true });
+	}
+
 	writeFileSync(historyPath, JSON.stringify(history, null, 2), "utf-8");
 }
 

--- a/src/lib/ai-edits.ts
+++ b/src/lib/ai-edits.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { git } from "../utils/git";
@@ -63,19 +63,8 @@ async function loadHistory(): Promise<AiEditedOutputHistory> {
 		const globalPath = await getGlobalHistoryPath();
 		const localPath = await getLocalHistoryPath();
 
-		let historyPath: string | undefined;
-
-		if (storage === "global") {
-			if (existsSync(globalPath)) {
-				historyPath = globalPath;
-			} else if (existsSync(localPath)) {
-				historyPath = localPath;
-			}
-		} else {
-			if (existsSync(localPath)) {
-				historyPath = localPath;
-			}
-		}
+		const pathsToCheck = storage === "global" ? [globalPath, localPath] : [localPath];
+		const historyPath = pathsToCheck.find((path) => existsSync(path));
 
 		if (!historyPath) {
 			return { entries: [] };
@@ -95,20 +84,30 @@ async function loadHistory(): Promise<AiEditedOutputHistory> {
 async function saveHistory(history: AiEditedOutputHistory): Promise<void> {
 	const config = await getConfig();
 	const storage = config.aiEdits?.storage || "local";
+	let historyPath: string;
 
 	if (storage === "global") {
-		const historyPath = await getGlobalHistoryPath();
+		historyPath = await getGlobalHistoryPath();
 		const historyDir = dirname(historyPath);
-
 		if (!existsSync(historyDir)) {
 			mkdirSync(historyDir, { recursive: true });
 		}
-
-		writeFileSync(historyPath, JSON.stringify(history, null, 2), "utf-8");
 	} else {
 		await ensureConfigDir();
-		const historyPath = await getLocalHistoryPath();
-		writeFileSync(historyPath, JSON.stringify(history, null, 2), "utf-8");
+		historyPath = await getLocalHistoryPath();
+	}
+
+	writeFileSync(historyPath, JSON.stringify(history, null, 2), "utf-8");
+
+	if (storage === "global") {
+		try {
+			const localPath = await getLocalHistoryPath();
+			if (existsSync(localPath)) {
+				unlinkSync(localPath);
+			}
+		} catch {
+			// Non-critical, ignore error.
+		}
 	}
 }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -82,6 +82,9 @@ export interface OcConfig {
 		/** If true, skip the startup mode prompt and use executionMode */
 		skipModePrompt?: boolean;
 	};
+	aiEdits?: {
+		storage?: "local" | "global";
+	};
 }
 
 const DEFAULT_JSON_CONFIG: OcConfig = {
@@ -118,6 +121,9 @@ const DEFAULT_JSON_CONFIG: OcConfig = {
 	defaults: {
 		executionMode: undefined,
 		skipModePrompt: false,
+	},
+	aiEdits: {
+		storage: "local",
 	},
 };
 


### PR DESCRIPTION
Updated the ai-edits history helpers to reuse a single repo root lookup per load/save call, and pass that into getGlobalHistoryPath, getLocalHistoryPath, and ensureConfigDir. This addresses the PR comments about redundant getRepoRoot() calls. 