### PR TITLE
Support multi-line PR description editing

### DIFF
--- a/src/lib/pr.ts
+++ b/src/lib/pr.ts
@@ -26,6 +26,7 @@ import {
 import { generatePRContent, type PRContent } from "./opencode";
 import { createSpinner, isInteractiveMode } from "../utils/ui";
 import { interactiveContentLoop } from "../utils/interactive-content";
+import { openEditor } from "../utils/editor";
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -291,12 +292,11 @@ async function resolvePRContent(
 				return null;
 			}
 
-			const editedBody = await p.text({
-				message: "Enter PR body:",
-				initialValue: current.body,
-			});
+			p.log.info("Opening editor for PR body...");
+			const editedBody = await openEditor(current.body);
 
-			if (p.isCancel(editedBody)) {
+			if (editedBody === null) {
+				p.log.warn("Editor exited without saving or with an error");
 				return null;
 			}
 

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -1,0 +1,60 @@
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Opens the user's preferred text editor to edit the provided content.
+ * Falls back to 'vim' if no VISUAL or EDITOR environment variable is set.
+ */
+export async function openEditor(
+	initialContent: string,
+): Promise<string | null> {
+	const editorCommand = process.env.VISUAL || process.env.EDITOR || "vim";
+	const tmpFile = join(
+		tmpdir(),
+		`oc-edit-${Math.random().toString(36).slice(2)}.md`,
+	);
+
+	await fs.writeFile(tmpFile, initialContent);
+
+	return new Promise((resolve, reject) => {
+		// Use shell: true to support editor commands with arguments (e.g., "code --wait")
+		const child = spawn(editorCommand, [tmpFile], {
+			stdio: "inherit",
+			shell: true,
+		});
+
+		child.on("exit", async (code) => {
+			if (code === 0) {
+				try {
+					const content = await fs.readFile(tmpFile, "utf-8");
+					await fs.unlink(tmpFile);
+					resolve(content.trim());
+				} catch (err) {
+					reject(err);
+				}
+			} else {
+				try {
+					await fs.unlink(tmpFile);
+				} catch {
+					// ignore
+				}
+				resolve(null);
+			}
+		});
+
+		child.on("error", async (err) => {
+			try {
+				await fs.unlink(tmpFile);
+			} catch {
+				// ignore
+			}
+			reject(
+				new Error(
+					`Failed to start editor (${editorCommand}): ${err instanceof Error ? err.message : String(err)}`,
+				),
+			);
+		});
+	});
+}


### PR DESCRIPTION
This PR updates the PR description edit feature to support multi-line editing using a full-text editor like vim or nano.

Key changes:
1.  **New Editor Utility**: Added `src/utils/editor.ts` which provides an `openEditor` function. This function handles creating a temporary file, spawning the editor process (supporting commands with arguments), and reading the edited content back. It respects `VISUAL` and `EDITOR` environment variables.
2.  **PR Flow Integration**: In `src/lib/pr.ts`, the `onEdit` callback now uses `openEditor` for the PR body instead of the single-line `p.text` prompt. The PR title still uses `p.text` for convenient validation and one-line input.
3.  **Robustness**: The editor utility includes improved error handling and supports shell commands, ensuring compatibility with various user configurations.

These changes allow users to easily review and refine AI-generated PR descriptions that often span multiple lines.

---
*PR created automatically by Jules for task [11783544233381074387](https://jules.google.com/task/11783544233381074387) started by @iHildy*