### PR TITLE
Update PR description edit to use full-text editor

### DIFF
--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -2,7 +2,6 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
 import color from "picocolors";
-import { confirmAction } from "../utils/confirm";
 import {
 	addHistoryEntry,
 	formatHistoryEntry,
@@ -13,6 +12,7 @@ import {
 	generateChangelog,
 	updateChangelogFile,
 } from "../lib/opencode";
+import { confirmAction } from "../utils/confirm";
 import {
 	detectVersionBump,
 	getCommitsBetween,

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -1,12 +1,12 @@
 import * as p from "@clack/prompts";
 import color from "picocolors";
-import { maybeCreateBranchForCommit } from "../lib/branch";
-import { getConfig } from "../lib/config";
 import {
 	getAiEditedOutputsContext,
 	recordAiEditedOutput,
 	recordAiEditedOutputSession,
 } from "../lib/ai-edits";
+import { maybeCreateBranchForCommit } from "../lib/branch";
+import { getConfig } from "../lib/config";
 import { cleanup, generateCommitMessage } from "../lib/opencode";
 import { maybeCreatePRAfterCommit } from "../lib/pr";
 import { confirmAction } from "../utils/confirm";
@@ -24,8 +24,8 @@ import {
 	promptForIntent,
 	replaceCommitIntent,
 } from "../utils/intent";
-import { createSpinner } from "../utils/ui";
 import { interactiveContentLoop } from "../utils/interactive-content";
+import { createSpinner } from "../utils/ui";
 
 export interface CommitOptions {
 	message?: string;

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -2,8 +2,8 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
 import color from "picocolors";
-import { maybeCreateBranchForCommit } from "../lib/branch";
 import { getAiEditedOutputsContext } from "../lib/ai-edits";
+import { maybeCreateBranchForCommit } from "../lib/branch";
 import { addHistoryEntry } from "../lib/history";
 import {
 	cleanup,

--- a/src/lib/branch.ts
+++ b/src/lib/branch.ts
@@ -12,15 +12,15 @@ import {
 	promptForIntent,
 	replaceBranchIntent,
 } from "../utils/intent";
-import { getConfig } from "./config";
+import { interactiveContentLoop } from "../utils/interactive-content";
+import { createSpinner } from "../utils/ui";
 import {
 	getAiEditedOutputsContext,
 	recordAiEditedOutput,
 	recordAiEditedOutputSession,
 } from "./ai-edits";
+import { getConfig } from "./config";
 import { generateBranchName } from "./opencode";
-import { createSpinner } from "../utils/ui";
-import { interactiveContentLoop } from "../utils/interactive-content";
 
 export type BranchFlowResult = "continue" | "abort";
 
@@ -197,7 +197,9 @@ export async function maybeCreateBranchForCommit(
 	} else if (yes) {
 		shouldCreate = isDefaultBranch ? autoOnDefault : autoOnNonDefault;
 	} else {
-		const branchInfo = color.white(`"${currentBranch}"`) + (isDefaultBranch ? ` ${color.dim("(default)")}` : "");
+		const branchInfo =
+			color.white(`"${currentBranch}"`) +
+			(isDefaultBranch ? ` ${color.dim("(default)")}` : "");
 		const message = `Create a new branch for this commit?\n${color.white("  Current branch: ")}${branchInfo}`;
 		const defaultValue = isDefaultBranch ? autoOnDefault : autoOnNonDefault;
 		const confirmResult = await confirmAction(message, defaultValue);

--- a/src/lib/defaults.ts
+++ b/src/lib/defaults.ts
@@ -1,7 +1,7 @@
 import * as p from "@clack/prompts";
 import type { ExecutionMode } from "../types/mode";
-import { getConfig } from "./config";
 import { setExecutionMode } from "../utils/ui";
+import { getConfig } from "./config";
 
 /**
  * Prompt user to select execution mode at startup.

--- a/src/lib/opencode.ts
+++ b/src/lib/opencode.ts
@@ -2,9 +2,9 @@ import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import * as p from "@clack/prompts";
 import {
+	type AssistantMessage,
 	createOpencode,
 	createOpencodeClient,
-	type AssistantMessage,
 	type OpencodeClient,
 	type Part,
 	type TextPart,

--- a/src/lib/pr.ts
+++ b/src/lib/pr.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util";
 import * as p from "@clack/prompts";
 import color from "picocolors";
 import { confirmAction } from "../utils/confirm";
+import { editWithEditor } from "../utils/editor";
 import {
 	getCommitsFromBranch,
 	getCurrentBranch,
@@ -17,15 +18,15 @@ import {
 	promptForIntent,
 	replaceCommitIntent,
 } from "../utils/intent";
-import { getConfig } from "./config";
+import { interactiveContentLoop } from "../utils/interactive-content";
+import { createSpinner, isInteractiveMode } from "../utils/ui";
 import {
 	getAiEditedOutputsContext,
 	recordAiEditedOutput,
 	recordAiEditedOutputSession,
 } from "./ai-edits";
+import { getConfig } from "./config";
 import { generatePRContent, type PRContent } from "./opencode";
-import { createSpinner, isInteractiveMode } from "../utils/ui";
-import { interactiveContentLoop } from "../utils/interactive-content";
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -291,12 +292,11 @@ async function resolvePRContent(
 				return null;
 			}
 
-			const editedBody = await p.text({
-				message: "Enter PR body:",
-				initialValue: current.body,
-			});
+			p.log.info("Opening editor to edit PR body...");
+			const editedBody = await editWithEditor(current.body);
 
-			if (p.isCancel(editedBody)) {
+			if (editedBody === null) {
+				p.log.error("Failed to edit PR body.");
 				return null;
 			}
 

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -1,0 +1,55 @@
+import { spawn } from "node:child_process";
+import { readFile, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export async function editWithEditor(
+	initialContent: string,
+	extension = "md",
+): Promise<string | null> {
+	const editor =
+		process.env.EDITOR || (process.platform === "win32" ? "notepad" : "vi");
+	const tmpFile = join(tmpdir(), `ocmt_edit_${Date.now()}.${extension}`);
+
+	try {
+		await writeFile(tmpFile, initialContent, "utf8");
+
+		return new Promise((resolve) => {
+			// Split editor command in case it has arguments (e.g. "code --wait")
+			const [cmd, ...args] = editor.split(" ");
+
+			const child = spawn(cmd, [...args, tmpFile], {
+				stdio: "inherit",
+			});
+
+			child.on("exit", async (code) => {
+				if (code === 0) {
+					try {
+						const content = await readFile(tmpFile, "utf8");
+						await unlink(tmpFile);
+						resolve(content);
+					} catch {
+						try {
+							await unlink(tmpFile);
+						} catch {}
+						resolve(null);
+					}
+				} else {
+					try {
+						await unlink(tmpFile);
+					} catch {}
+					resolve(null);
+				}
+			});
+
+			child.on("error", async () => {
+				try {
+					await unlink(tmpFile);
+				} catch {}
+				resolve(null);
+			});
+		});
+	} catch {
+		return null;
+	}
+}

--- a/src/utils/interactive-content.ts
+++ b/src/utils/interactive-content.ts
@@ -26,9 +26,7 @@ export async function interactiveContentLoop<T>(
 ): Promise<ActionLoopResult<T>> {
 	const confirmContent =
 		config.confirmContent ??
-		(typeof config.content === "string"
-			? config.content
-			: config.contentLabel);
+		(typeof config.content === "string" ? config.content : config.contentLabel);
 	const shouldDisplay = !config.skipInitialDisplay;
 
 	if (shouldDisplay) {
@@ -126,7 +124,6 @@ export async function interactiveContentLoop<T>(
 			generated = current;
 			wasEdited = false;
 			config.displayContent(current);
-			continue;
 		}
 	}
 }


### PR DESCRIPTION
Updated the PR description edit feature to support multi-line editing by launching the user's preferred external text editor (via `EDITOR` environment variable, defaulting to `vi` or `notepad`). This replaces the previous single-line input prompt for the PR body. Added a new `editWithEditor` utility function to handle the editor process.

---
*PR created automatically by Jules for task [10130657865896986026](https://jules.google.com/task/10130657865896986026) started by @iHildy*